### PR TITLE
Fix Redis reliability and modernize tooling for .NET 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
 
   test:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
     steps:
       - checkout
@@ -47,7 +47,7 @@ jobs:
 
   semver:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
     steps:
       - checkout
@@ -68,7 +68,7 @@ jobs:
 
   deploy_nuget:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ jobs:
       - run:
           name: Restore Dependencies
           command: |
-            cd src/Lasso
-            dotnet restore
+            dotnet restore src/Lasso/Lasso.sln
+            dotnet restore demo/LassoDemo.csproj
 
       - run:
           name: Build
           command: |
-            cd src/Lasso
-            dotnet build $lib
+            dotnet build src/Lasso/Lasso.sln --no-restore
+            dotnet build demo/LassoDemo.csproj --no-restore
 
   test:
     docker:

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,334 @@
+# Lasso — Validated Code Review
+
+Date: 2026-08-11  
+Reviewed commit: `e53a49f`  
+Scope: `src/Lasso`, `src/Lasso.Extensions.DependencyInjection`, `src/Lasso.Tests`, `demo`, `README.md`, and `.circleci/config.yml`
+
+## Validation performed
+
+This revision re-checked every assertion in the original review against source, builds, runtime probes, and upstream Redis/StackExchange.Redis behavior.
+
+Observed evidence:
+
+- `dotnet build src/Lasso/Lasso.csproj`: succeeds with one warning, `CS0169` for the unused `RedisUsageManager.connection` field.
+- `dotnet build src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj`: succeeds.
+- `dotnet build demo/LassoDemo.csproj`: fails with five compiler errors: wrong `RedisUsageManager` constructor, missing `UsageRequest` constructor arguments, and three assignments to read-only properties. It also warns that `exp.Value` may be null.
+- DI runtime probes reproduced:
+  - parameterless `AddDefaultLasso()` throws during registration;
+  - `AddLasso()` plus key/expiration builders fails to resolve `IUsageManager` because `IOptions<LassoOptions>` was not registered;
+  - `AddLasso(configureOptions)` without a key builder/expiration strategy fails to resolve `IUsageManager`;
+  - registering both fixed and relative strategies makes the two `RedisUsageManager` constructors ambiguous;
+  - default `AddLogging()` does not register non-generic `ILogger`, so `RedisUsageManager` receives its optional null value and constructs a no-op logger from `NullLoggerFactory`.
+- Date-format probes for `2026-08-11` produced `20260811` under `en-US`, `14480228` under `ar-SA`, `14050520` under `fa-IR`, and `25690811` under `th-TH`.
+- StackExchange.Redis 2.6.122 source confirms `KeyExpireTimeAsync` sends `PEXPIRETIME`, while conditional expiry sends `PEXPIRE`/`EXPIRE` with `NX` for `ExpireWhen.HasNoExpiry`.
+- Redis documentation marks `PEXPIRETIME` and conditional `EXPIRE ... NX|XX|GT|LT` as Redis 7.0 additions.
+- `dotnet list ... package --vulnerable --include-transitive` reported no known vulnerable packages for either library project using the currently configured JFrog NuGet source. This is not a guarantee against advisories absent from that feed.
+
+---
+
+## Confirmed findings
+
+### High severity
+
+#### H1. Failed batched flushes permanently lose the pending delta
+
+`BatchedUsageManager.PushAsync` clears `delta` before awaiting the underlying Redis write:
+
+```csharp
+long d = Interlocked.Exchange(ref delta, 0);
+return await usageManager.IncrementAsync(this.request, d);
+```
+
+If `IncrementAsync` throws before Redis applies the command, `d` is never restored and the next flush sees only increments added after the failed exchange. If Redis applied the command but the response was lost, retrying the same delta would instead double-count. The current API has no operation ID or documented at-most-once/at-least-once policy, so callers cannot recover safely from an ambiguous Redis timeout.
+
+Location: `src/Lasso/BatchedUsageManager.cs:33-37`.
+
+Fix: first define the delivery guarantee. For retryable, exactly-once-within-retention behavior, attach a unique flush ID and use Lua to atomically deduplicate that ID while applying the delta. A simpler catch path that blindly restores `d` changes loss into possible duplication and is not sufficient. Serialize flushes and add tests for definite pre-send failure, ambiguous timeout, and concurrent increments.
+
+#### H2. Disposing `RedisUsageManager` disposes a caller-owned multiplexer
+
+When `LassoOptions.ConnectionMultiplexer` is supplied, `ConnectSlowAsync` uses that external instance. `Dispose` later obtains it through `cache.Multiplexer`, calls `Close()`, and disposes it unconditionally.
+
+Locations: `src/Lasso/RedisUsageManager.cs:177-193`, `src/Lasso/RedisUsageManager.cs:253-285`.
+
+`ConnectionMultiplexer` is designed to be shared. A component receiving one from a caller should not take ownership unless the contract says so. Manual disposal of the manager can break unrelated Redis consumers using the same multiplexer.
+
+Fix: track whether the manager created the multiplexer. Dispose it only when owned. Do not dispose an instance supplied through options.
+
+#### H3. Built-in key builders depend on the process culture
+
+The daily, hourly, and monthly builders call `DateTime.ToString` without `CultureInfo.InvariantCulture`. Custom date patterns still use the current culture's calendar, producing different key periods on hosts with different locale settings. The runtime probe demonstrated different years/months/days for `ar-SA`, `fa-IR`, and `th-TH`.
+
+Locations:
+
+- `src/Lasso/DailyUtcRedisKeyBuilder.cs:9`
+- `src/Lasso/HourlyUtcRedisKeyBuilder.cs:9`
+- `src/Lasso/MonthlyUtcRedisKeyBuilder.cs:9`
+
+In a mixed-locale deployment, identical requests can be split across different Redis keys and quota totals.
+
+Fix: format with `CultureInfo.InvariantCulture`. The original review's reference to non-ASCII digits was too broad; the reproduced problem is the culture-specific calendar value.
+
+#### H4. The demo and README example do not compile against the current API
+
+Both use a removed/nonexistent constructor:
+
+```csharp
+new RedisUsageManager(muxer, keyBuilder, expirationStrategy)
+```
+
+Both also construct `UsageRequest` with a parameterless object initializer even though it now has only `UsageRequest(string resource, string context, long quota)` and get-only properties.
+
+Locations: `demo/Program.cs:18-23`, `README.md` usage example.
+
+The demo build reproduced all five errors. `demo/Program.cs:31` and the README also dereference nullable `exp.Value` without checking it.
+
+Fix the examples and build the demo in PR CI.
+
+#### H5. Parameterless `AddDefaultLasso()` always throws
+
+`AddDefaultLasso(configureOptions)` already registers the hourly key builder and relative expiration strategy. The parameterless overload calls it and registers both again. The duplicate guard throws immediately; the runtime probe reproduced:
+
+```text
+InvalidOperationException: A IRedisKeyBuilder provider has already been registered.
+```
+
+Location: `src/Lasso.Extensions.DependencyInjection/LassoServiceDependencyInjectionExtensions.cs:81-99`.
+
+Fix: return `services.AddDefaultLasso(options => options.RedisConfiguration = "localhost:6379")` without chaining duplicate registrations.
+
+### Medium severity
+
+#### M1. Creating a Redis key and assigning its expiry are not atomic
+
+`IncrementAsync`, `DecrementAsync`, and `ResetAsync` first mutate the hash, then issue expiry as a separate command. If the process dies after creating a new hash key but before expiry succeeds, that new key remains persistent.
+
+Location: `src/Lasso/RedisUsageManager.cs:67-108`.
+
+Important correction to the original review: mutating an existing Redis hash does not clear an existing TTL. The leak window applies when the operation creates a new key with no prior expiry; it is not a risk on every update.
+
+Fix: use one Lua script for mutation plus conditional expiry. This also reduces the hot path from two network round trips to one. `IBatch` pipelines but does not make the pair atomic.
+
+#### M2. The effective Redis 7.0+ requirement is undocumented
+
+For non-sliding relative expiration, `ExpireWhen.HasNoExpiry` is encoded as `PEXPIRE/EXPIRE ... NX`; the conditional options were added in Redis 7.0. `GetExpirationAsync` uses `PEXPIRETIME`, also added in Redis 7.0.
+
+Locations: `src/Lasso/RedisUsageManager.cs:123-151`; StackExchange.Redis 2.6.122 `RedisDatabase.cs` expiry implementation.
+
+Scope correction: not every operation/configuration requires Redis 7. Sliding expiry with `ExpireWhen.Always` and fixed expiry use older commands. However, non-sliding relative expiry and `GetExpirationAsync` fail on Redis 6.x.
+
+Fix: document Redis 7.0 as the minimum, or implement a compatibility path. A compatibility path for `NX` must preserve atomicity; a separate TTL check followed by EXPIRE is racy.
+
+References:
+
+- <https://redis.io/docs/latest/commands/expire/>
+- <https://redis.io/docs/latest/commands/pexpiretime/>
+
+#### M3. The DI registration API exposes several configurations that fail only at resolution
+
+Confirmed cases:
+
+1. `AddLasso()` registers `IUsageManager` but not `IOptions<LassoOptions>`. Even after chaining a key builder and expiration strategy, resolution fails unless options were registered independently.
+2. `AddLasso(configureOptions)` registers options, but resolution still fails if the caller does not chain a key builder and exactly one expiration strategy.
+3. Registering both fixed and relative expiration strategies is allowed by the builders, then causes an ambiguous-constructor exception when `IUsageManager` is resolved.
+
+Locations: `src/Lasso.Extensions.DependencyInjection/LassoServiceDependencyInjectionExtensions.cs:16-87`, and the two public constructors in `src/Lasso/RedisUsageManager.cs:31-49`.
+
+Fix:
+
+- make `AddLasso()` call `AddOptions<LassoOptions>()`;
+- validate connection configuration and required strategy registrations at startup;
+- replace the two ambiguous constructors with one unambiguous dependency, preferably a single strategy contract/discriminated options value.
+
+A unified expiration abstraction may be useful, but the original review's proposed `TimeSpan?` interface was incomplete because it could not represent absolute expiration.
+
+#### M4. `BatchedUsageManager` remains usable after disposal and is not safe around concurrent disposal
+
+`disposedValue` is only consulted by `Dispose`. `Increment`, `Decrement`, and `PushAsync` do not check it. Calls made after disposal continue accumulating deltas that will never be automatically flushed.
+
+A concurrent increment can also race with the unsynchronized `if (delta != 0)` check in `Dispose` and remain pending after disposal.
+
+Locations: `src/Lasso/BatchedUsageManager.cs:21-60`.
+
+Fix: define lifecycle semantics, reject calls after disposal, and coordinate increment/flush/dispose state. The class claims thread safety in the README, so disposal races are part of the public reliability contract unless explicitly excluded.
+
+#### M5. Synchronous disposal blocks on asynchronous I/O
+
+`Dispose` calls `PushAsync().Wait()`. An arbitrary `IUsageManager` implementation may capture a synchronization context, causing deadlock; failures are also wrapped in `AggregateException`.
+
+Location: `src/Lasso/BatchedUsageManager.cs:39-53`.
+
+Fix: expose an explicit `FlushAsync(CancellationToken)` and an async-disposal path where target-framework support permits it. Do not make synchronous `Dispose` silently discard pending data; the replacement contract must state whether sync disposal blocks, refuses pending work, or delegates to an async lifecycle.
+
+#### M6. Configured DI logging is ignored, and the logger field is dead
+
+`RedisUsageManager` asks for non-generic `ILogger`. Default `AddLogging()` registers `ILogger<T>`, not non-generic `ILogger`, so DI supplies the constructor's optional null value. The constructor then creates a no-op logger from `NullLoggerFactory`. The stored logger is never used; the only warning path uses `Trace.TraceWarning`.
+
+Locations: `src/Lasso/RedisUsageManager.cs:23-50`, `src/Lasso/RedisUsageManager.cs:134-151`.
+
+Fix: either remove logging from the class, or inject and use `ILogger<RedisUsageManager>`. The original statement that "all log output disappears" overstated the current effect: there are no `logger` calls to disappear; the real problem is a nonfunctional logging abstraction.
+
+#### M7. Options fail late and opaquely
+
+If neither `ConnectionMultiplexer`, `RedisConfigurationOptions`, nor `RedisConfiguration` is set, `ConnectSlowAsync` passes null into StackExchange.Redis. Invalid configuration is discovered on first usage rather than at application startup.
+
+Location: `src/Lasso/RedisUsageManager.cs:177-193`.
+
+Fix: add `IValidateOptions<LassoOptions>` in the DI package and a constructor guard for direct consumers. Require at least one usable connection source and validate the highest-precedence source when multiple are supplied.
+
+#### M8. CI does not compile all shipped projects
+
+The PR build job compiles only `src/Lasso`; it does not compile the DI package or demo. The deploy job updates version files in the DI directory but only packs the core project. This allowed the broken demo/README contract to persist.
+
+Location: `.circleci/config.yml`.
+
+Fix: build a root solution containing core, DI, tests, and demo. Keep packaging as a separate job.
+
+#### M9. CI and tests target EOL .NET 6
+
+`.circleci/config.yml` uses `mcr.microsoft.com/dotnet/sdk:6.0-alpine`, and `Lasso.Tests.csproj` targets `net6.0`. .NET 6 has been out of support since 2024-11-12.
+
+Fix: move CI/tests to a supported LTS SDK while retaining `netstandard2.0` for the library if that compatibility target is still required.
+
+### Low severity / maintainability
+
+#### L1. Null guards omit parameter names
+
+`ArgumentNullThrowHelper.ThrowIfNull` defaults `paramName` to null, and callers never pass it. Consumers receive `ArgumentNullException` without the failing parameter name.
+
+Location: `src/Lasso/ThrowHelpers.cs` and its call sites.
+
+Fix: pass `nameof(...)` explicitly or use a `CallerArgumentExpression` compatibility attribute.
+
+#### L2. `SetExpirationAsync` repeats connection lookup
+
+Each caller has already awaited `ConnectAsync`, then `SetExpirationAsync` does it again. More importantly, callers ignore the returned `IDatabase` and read the shared field.
+
+Locations: `src/Lasso/RedisUsageManager.cs:53-151`.
+
+Fix: capture `IDatabase database = await ConnectAsync(...)` once and pass it into expiration handling. The original review described this as a general null-race. That was overstated: with `OnRedisError` unreachable, the practical race is concurrent disposal, which is normally outside an `IDisposable` object's supported lifecycle. Treat this as cleanup/performance, not a high-severity concurrency bug.
+
+#### L3. Fixed-expiration `DateTimeKind.Unspecified` fails only on first Redis operation
+
+StackExchange.Redis 2.6.122 converts `Local` to UTC and accepts `Utc`, but throws for `DateTimeKind.Unspecified`. `DateTimeExpirationStrategy` accepts any `DateTime`, delaying this error until expiry is applied.
+
+Location: `src/Lasso/DateTimeExpirationStrategy.cs`.
+
+Fix: validate the kind in the strategy constructor. Correction: the original review incorrectly said local values silently shift; they are deliberately converted to UTC.
+
+#### L4. `DeleteAsync` always issues an expiry operation after deletion
+
+If the deleted field was the last hash field, Redis removes the key and the subsequent expiry command is a no-op. If other fields remain and expiration is sliding, deletion renews their shared key TTL. The latter may be intended, but it should be explicit.
+
+Location: `src/Lasso/RedisUsageManager.cs:109-121`.
+
+Do not add a standalone `HLEN` merely to avoid this call; that adds another round trip and race. If mutation/expiry is moved to Lua, return enough state from the script to handle it atomically.
+
+#### L5. Cancellation behavior is inconsistent and limited
+
+The public token cancels before work and while waiting for `connectionLock`; StackExchange.Redis 2.6.122 operations themselves do not accept it. `GetAsync`, `ResetAsync`, and `DeleteAsync` also omit the token when calling `SetExpirationAsync`, unlike increment/decrement.
+
+Fix: pass the token consistently and document that Redis command timeout is controlled by StackExchange.Redis configuration, not by the method token.
+
+#### L6. Tests mix integration, timing, and unit concerns
+
+- Most `RedisUsageManagerTests` require a live Redis server at `127.0.0.1:6379`.
+- `One_Thousand_Increments_Perf_Test` asserts completion under two seconds, a machine/load-dependent threshold.
+- Many tests block with `.Result` instead of using `async Task`.
+- There are no DI tests for the failure cases reproduced above.
+- There are no batched-write failure/disposal-race tests.
+
+Fix: label/split Redis integration tests, move throughput measurement to BenchmarkDotNet or remove the wall-clock assertion, use async tests, and add contract tests for DI registration and failed batch flushes.
+
+#### L7. Dead code and consistency issues
+
+Confirmed cleanup:
+
+- unused `RedisUsageManager.connection` field (`CS0169`);
+- unreachable `OnRedisError` and its large commented-out reconnect implementation;
+- unreachable "no expiration strategy" branch because both public constructors require and validate a strategy;
+- unused `logger` field in practice;
+- large commented-out DI connection code;
+- duplicate `<ImplicitUsings>` entries in both library project files;
+- unused imports such as `System.Data.Common`;
+- mixed `default` and `default(CancellationToken)` syntax;
+- XML typo `Lass0`.
+
+#### L8. Counter overflow semantics are inconsistent
+
+`Interlocked.Add` wraps a `long` delta on overflow, while Redis `HINCRBY` reports an error when its signed 64-bit result would overflow. A sufficiently large accumulated batch can therefore send a corrupted wrapped delta rather than failing.
+
+Location: `src/Lasso/BatchedUsageManager.cs:21-36`.
+
+This is an edge case, but a usage-accounting library should choose explicit checked/unchecked semantics and test them.
+
+---
+
+## Performance findings
+
+### P1. Mutating operations use two sequential Redis round trips
+
+The hash command is awaited before the expiry command is sent. Network RTT dominates the local allocations and branches in these methods.
+
+Preferred fix: one Lua script that returns the updated counter and applies expiry atomically. This addresses both performance and M1.
+
+Do not use `CommandFlags.FireAndForget` for expiry as the original review suggested. Losing an expiry command creates persistent keys and weakens data reliability.
+
+### P2. `GetAsync` is a write for sliding expiration
+
+`GetAsync` reads the hash and then refreshes the key expiry when sliding expiration is configured. This is consistent with sliding-expiration semantics, but callers should know that reads create master write load and cost a second RTT.
+
+This is an operational behavior to document, not necessarily a defect or a reason to change the API.
+
+### P3. Local key-format allocations are not currently worth optimizing
+
+The original review suggested caching daily/monthly formatted prefixes. That is premature relative to the Redis network cost and introduces rollover/concurrency complexity. Use invariant formatting for correctness; optimize allocation only after benchmarking shows it matters.
+
+---
+
+## Security assessment
+
+No direct injection, credential exposure, or known dependency vulnerability was found in the reviewed code:
+
+- Redis keys and hash fields are passed as StackExchange.Redis values, not concatenated into raw Redis commands.
+- `ConfigurationOptions` already supports authentication and TLS; the original claim that Lasso lacked first-class TLS/auth support was incorrect.
+- No configured connection string or password is logged.
+- The package vulnerability scan was clean against the configured NuGet feed.
+
+Remaining operational responsibilities should be documented rather than implemented as library policy: keep credentials outside source, enable TLS for remote Redis, restrict Redis network access, and constrain user-controlled key cardinality at the application boundary.
+
+The original concern about NuGet and SSH credentials existing in one CI job was speculative and not a code-review finding; it has been removed.
+
+---
+
+## Findings rejected or downgraded from the original review
+
+1. **"No reconnect path leaves a broken `IDatabase` forever" — rejected.** StackExchange.Redis automatically reconnects in the background and explicitly recommends sharing/reusing a `ConnectionMultiplexer`. `IDatabase` is a lightweight proxy over it. `OnRedisError` is dead code and should be deleted, not wired up as a custom reconnect loop. Replacing the multiplexer on every connection exception would fight the client's intended behavior.
+2. **"A colon in `Context` causes key collisions" — rejected.** For a fixed timestamp prefix, `prefix + ":" + context` is injective over distinct context strings; embedded colons do not create collisions. A configurable application prefix could still be useful for shared Redis databases, but that is namespacing, not collision prevention.
+3. **"Missing atomic quota enforcement is a core defect" — rejected as a defect.** The README explicitly says Lasso is a record keeper and does not prescribe outcomes when thresholds are crossed. `TryIncrementWithinQuotaAsync` could be a useful optional product feature, but it changes the stated scope.
+4. **"BatchedUsageManager should implement `IUsageManager`" — rejected.** Its buffered synchronous increment/flush contract is materially different from the full read/reset/delete interface. If consumers need DI substitution, define a separate batching interface; forcing it into `IUsageManager` would be a leaky abstraction.
+5. **"The no-strategy warning logs on every operation" — rejected.** The branch is unreachable through public constructors because each requires and null-validates one strategy. Delete the dead branch.
+6. **"Non-sliding expiration semantics are surprising and undocumented" — rejected.** The README states that a 24-hour relative expiration begins when usage starts. The first-write anchored behavior is already described.
+7. **"`DateTime.MaxValue`/`TimeSpan.MaxValue` are undocumented magic" — rejected.** The README documents both, and StackExchange.Redis itself treats null/`MaxValue` expiry as `PERSIST` in this API version.
+8. **"Skip zero-delta pushes" — withdrawn.** `PushAsync` returns a current `UsageResult`; skipping the call would require cached state or a different return contract. The zero write may be wasteful, but the prior fix was incomplete.
+9. **"Plain `disposedValue` in RedisUsageManager is a material memory-model bug" — downgraded.** Concurrent use during disposal is not generally guaranteed for `IDisposable`. Reusing the returned database is cleaner, but this is not a priority unless concurrent disposal becomes an explicit contract.
+10. **"Cache formatted key prefixes" — rejected absent benchmarks.** Redis RTT dominates; correctness comes first.
+11. **"Use fire-and-forget expiry" — rejected.** It conflicts with reliable key expiry.
+12. **"Local `DateTime` silently shifts expiry" — rejected.** StackExchange.Redis converts `Local` to UTC and rejects `Unspecified`.
+
+---
+
+## Recommended order of work
+
+| Priority | Change | Why |
+|---|---|---|
+| 1 | Define batch delivery semantics and make flushes idempotent/recoverable | Prevents silent loss without introducing duplicate usage |
+| 2 | Stop disposing caller-owned multiplexers | Restores correct resource ownership |
+| 3 | Use invariant key formatting | Prevents cross-host quota splitting |
+| 4 | Fix DI registrations and constructor ambiguity; add DI tests | Multiple public setup paths currently throw |
+| 5 | Fix and CI-build demo/README example | Public contract currently does not compile |
+| 6 | Make mutation plus first expiry atomic with Lua | Prevents persistent orphan keys and halves RTTs |
+| 7 | Document or handle Redis 7 compatibility | Prevents runtime failures on Redis 6 |
+| 8 | Replace blocking batch disposal with an explicit lifecycle | Avoids deadlock and ambiguous failure handling |
+| 9 | Validate options and fixed `DateTime` values at startup | Converts late failures into actionable startup errors |
+| 10 | Upgrade test/CI runtime and split integration/perf tests | Removes EOL runtime and flaky coverage |

--- a/README.md
+++ b/README.md
@@ -38,19 +38,20 @@ Using Lasso only requires a few things.
 This example builds a composite key for `tenant_abc` per day, as in `20220318:tenant_abc` and expires it after 30 days, thereby keeping daily usage for the trailing 30 days. It increments usage for resource `background_service` and passes a quota value of `100` along with the request/response. It then gets the expiration for the key and displays the results in the console.
 
 ```csharp
-var redis = ConnectionMultiplexer.Connect("10.0.2.12:6379");
+using Microsoft.Extensions.Options;
+
+using var redis = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
 IRedisKeyBuilder keyBuilder = new DailyUtcRedisKeyBuilder();
 IRelativeExpirationStrategy expirationStrategy = new TimeSpanExpirationStrategy(TimeSpan.FromDays(30), sliding: false);
-IUsageManager usageManager = new RedisUsageManager(redis, keyBuilder, expirationStrategy);
+var options = Options.Create(new LassoOptions { ConnectionMultiplexer = redis });
+using var usageManager = new RedisUsageManager(options, keyBuilder, expirationStrategy);
 
-var usage = new UsageRequest
-{
-    Context = "tenant_abc",
-    Resource = "background_service",
-    Quota = 100
-};
+var usage = new UsageRequest("background_service", "tenant_abc", quota: 100);
 
 UsageResult res = await usageManager.IncrementAsync(usage);
-var exp = await usageManager.GetExpirationAsync(usage);
-Console.WriteLine($"Usage: {res.Current} / {res.Quota}, Resets in {exp.Value.Subtract(DateTime.UtcNow).TotalDays} days");
+DateTime? expiration = await usageManager.GetExpirationAsync(usage);
+string resetsIn = expiration.HasValue
+    ? $"{expiration.Value.Subtract(DateTime.UtcNow).TotalDays:F1} days"
+    : "never";
+Console.WriteLine($"Usage: {res.Current} / {res.Quota}, Resets in {resetsIn}");
 ```

--- a/demo/LassoDemo.csproj
+++ b/demo/LassoDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -1,6 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using Lasso;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
 const long MAX_REQ = 5;
@@ -11,24 +12,23 @@ Console.WriteLine("Press [Enter] to request a new GUID be generated and written 
 Console.WriteLine($"The maximum number of requests is {MAX_REQ} per {LIMIT_WINDOW_SEC} seconds.");
 Console.WriteLine();
 
-var muxer = ConnectionMultiplexer.Connect("10.0.2.12:6379");
+using var muxer = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
 IRedisKeyBuilder keyBuilder = new DailyUtcRedisKeyBuilder();
 IRelativeExpirationStrategy expirationStrategy = new TimeSpanExpirationStrategy(TimeSpan.FromSeconds(LIMIT_WINDOW_SEC), false);
 
-IUsageManager usageManager = new RedisUsageManager(muxer, keyBuilder, expirationStrategy);
-var usage = new UsageRequest
-{
-    Context = "LassoDemo",
-    Resource = "GuidGen",
-    Quota = MAX_REQ
-};
+var options = Options.Create(new LassoOptions { ConnectionMultiplexer = muxer });
+using var usageManager = new RedisUsageManager(options, keyBuilder, expirationStrategy);
+var usage = new UsageRequest("GuidGen", "LassoDemo", MAX_REQ);
 
 while (true)
 {
     Console.ReadLine();
     UsageResult res = await usageManager.IncrementAsync(usage);
     var exp = await usageManager.GetExpirationAsync(usage);
-    Console.WriteLine($"[Usage: {res.Current} / {res.Quota}, Resets in {exp.Value.Subtract(DateTime.UtcNow).TotalSeconds} seconds]");
+    string resetsIn = exp.HasValue
+        ? $"{exp.Value.Subtract(DateTime.UtcNow).TotalSeconds:F0} seconds"
+        : "never";
+    Console.WriteLine($"[Usage: {res.Current} / {res.Quota}, Resets in {resetsIn}]");
 
     if (res.Current <= res.Quota)
         Console.WriteLine(Guid.NewGuid().ToString());

--- a/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj
+++ b/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
   </ItemGroup>
 

--- a/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj
+++ b/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Joshua Marble</Authors>
     <PackageId>Lasso.Extensions.DependencyInjection</PackageId>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj
+++ b/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Joshua Marble</Authors>
     <PackageId>Lasso.Extensions.DependencyInjection</PackageId>

--- a/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.nuspec
+++ b/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.nuspec
@@ -14,16 +14,17 @@
     <readme>docs\README.md</readme>
     <license>docs\LICENSE</license>
     <dependencies>
-      <group targetFramework="netstandard2.0">
-        <dependency id="StackExchange.Redis" version="2.6.104" />
-        <dependency id="Lasso" version="0.9.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="7.0.0" />
-        <dependency id="Microsoft.Extensions.Options" version="7.0.1" />
+      <group targetFramework="net10.0">
+        <dependency id="StackExchange.Redis" version="3.1.13" />
+        <dependency id="Lasso" version="0.10.4" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" />
+        <dependency id="Microsoft.Extensions.Hosting" version="10.0.11" />
+        <dependency id="Microsoft.Extensions.Options" version="10.0.11" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Debug\netstandard2.0\Lasso.Extensions.DependencyInjection.dll" target="lib\netstandard2.0\Lasso.Extensions.DependencyInjection.dll" />
+    <file src="bin\Debug\net10.0\Lasso.Extensions.DependencyInjection.dll" target="lib\net10.0\Lasso.Extensions.DependencyInjection.dll" />
     <file src="..\..\README.md" target="docs\" />
     <file src="..\..\LICENSE" target="docs\" />
   </files>

--- a/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.nuspec
+++ b/src/Lasso.Extensions.DependencyInjection/Lasso.Extensions.DependencyInjection.nuspec
@@ -14,7 +14,7 @@
     <readme>docs\README.md</readme>
     <license>docs\LICENSE</license>
     <dependencies>
-      <group targetFramework="net10.0">
+      <group targetFramework="netstandard2.0">
         <dependency id="StackExchange.Redis" version="3.1.13" />
         <dependency id="Lasso" version="0.10.4" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" />
@@ -24,7 +24,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Debug\net10.0\Lasso.Extensions.DependencyInjection.dll" target="lib\net10.0\Lasso.Extensions.DependencyInjection.dll" />
+    <file src="bin\Debug\netstandard2.0\Lasso.Extensions.DependencyInjection.dll" target="lib\netstandard2.0\Lasso.Extensions.DependencyInjection.dll" />
     <file src="..\..\README.md" target="docs\" />
     <file src="..\..\LICENSE" target="docs\" />
   </files>

--- a/src/Lasso.Extensions.DependencyInjection/LassoServiceDependencyInjectionExtensions.cs
+++ b/src/Lasso.Extensions.DependencyInjection/LassoServiceDependencyInjectionExtensions.cs
@@ -1,15 +1,17 @@
 ﻿using System;
-using System.Data.Common;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using StackExchange.Redis;
 
 namespace Lasso.Extensions.DependencyInjection
 {
     public static class LassoServiceDependencyInjectionExtensions
     {
+        private const string MissingConnectionConfigurationMessage = "A Redis connection must be configured with ConnectionMultiplexer, RedisConfigurationOptions, or RedisConfiguration.";
+
         /// <summary>
-        /// Registers services required by Lass0.
+        /// Registers services required by Lasso.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>A <see cref="LassoServiceBuilder"/> that can be used to further configure Lasso.</returns>
@@ -20,39 +22,22 @@ namespace Lasso.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddSingleton<IUsageManager, RedisUsageManager>();
+            services.AddOptions<LassoOptions>()
+                .Validate(HasConnectionConfiguration, MissingConnectionConfigurationMessage)
+                .ValidateOnStart();
+            services.TryAddSingleton<IUsageManager>(CreateUsageManager);
 
             return new LassoServiceBuilder(services);
         }
         public static LassoServiceBuilder AddLasso(this IServiceCollection services, Action<LassoOptions> configureOptionsFactory)
         {
+            if (configureOptionsFactory == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptionsFactory));
+            }
+
             var builder = services.AddLasso();
-            
             services.Configure(configureOptionsFactory);
-            //LassoOptions configureOptions = new LassoOptions();
-            //configureOptionsFactory(configureOptions);
-            //IConnectionMultiplexer connection = null;
-            //if (configureOptions.RedisConfigurationOptions != null)
-            //{
-            //    connection = ConnectionMultiplexer.Connect(configureOptions.RedisConfigurationOptions);
-            //}
-            //else if(!string.IsNullOrWhiteSpace(configureOptions.RedisConfiguration))
-            //{
-            //    connection = ConnectionMultiplexer.Connect(configureOptions.RedisConfiguration);
-            //}
-            //if (connection != null)
-            //{
-            //    services.AddSingleton<IConnectionMultiplexer>(connection);
-            //}
-            
-
-            //*** Josh - this is an example
-            //services.AddStackExchangeRedisCache(options =>
-            //{
-            //    options.ConfigurationOptions
-            //});
-
-
             return builder;
         }
 
@@ -61,7 +46,6 @@ namespace Lasso.Extensions.DependencyInjection
             IRedisKeyBuilder keyBuilder,
             IRelativeExpirationStrategy relativeExpirationStrategy)
         {
-            //todo: can you do relative and static strategies both at the same time?
             return services.AddLasso(configureOptionsFactory)
                 .WithCustomKeyBuilder(keyBuilder)
                 .WithCustomRelativeExpirationStrategy(relativeExpirationStrategy);
@@ -72,7 +56,6 @@ namespace Lasso.Extensions.DependencyInjection
             IRedisKeyBuilder keyBuilder,
             IFixedExpirationStrategy fixedExpirationStrategy)
         {
-            //todo: can you do relative and static strategies both at the same time?
             return services.AddLasso(configureOptionsFactory)
                 .WithCustomKeyBuilder(keyBuilder)
                 .WithCustomFixedExpirationStrategy(fixedExpirationStrategy);
@@ -81,7 +64,6 @@ namespace Lasso.Extensions.DependencyInjection
         public static LassoServiceBuilder AddDefaultLasso(this IServiceCollection services,
             Action<LassoOptions> configureOptionsFactory)
         {
-            //todo: can you do relative and static strategies both at the same time?
             return services.AddLasso(configureOptionsFactory)
                 .WithHourlyUtcKeyBuilder()
                 .WithCustomRelativeExpirationStrategy(new TimeSpanExpirationStrategy(TimeSpan.FromMinutes(10), true));
@@ -89,13 +71,35 @@ namespace Lasso.Extensions.DependencyInjection
 
         public static LassoServiceBuilder AddDefaultLasso(this IServiceCollection services)
         {
-            //todo: can you do relative and static strategies both at the same time?
             return services.AddDefaultLasso(options =>
-                {
-                    options.RedisConfiguration = "localhost:6379";
-                })
-                .WithHourlyUtcKeyBuilder()
-                .WithCustomRelativeExpirationStrategy(new TimeSpanExpirationStrategy(TimeSpan.FromMinutes(10), true));
+            {
+                options.RedisConfiguration = "localhost:6379";
+            });
+        }
+
+        private static IUsageManager CreateUsageManager(IServiceProvider services)
+        {
+            var options = services.GetRequiredService<IOptions<LassoOptions>>();
+            var keyBuilder = services.GetRequiredService<IRedisKeyBuilder>();
+            var relativeExpirationStrategy = services.GetService<IRelativeExpirationStrategy>();
+            var fixedExpirationStrategy = services.GetService<IFixedExpirationStrategy>();
+            var logger = services.GetService<ILogger<RedisUsageManager>>();
+
+            if (relativeExpirationStrategy != null && fixedExpirationStrategy != null)
+                throw new InvalidOperationException("Only one expiration strategy can be registered.");
+            if (relativeExpirationStrategy != null)
+                return new RedisUsageManager(options, keyBuilder, relativeExpirationStrategy, logger);
+            if (fixedExpirationStrategy != null)
+                return new RedisUsageManager(options, keyBuilder, fixedExpirationStrategy, logger);
+
+            throw new InvalidOperationException("An expiration strategy must be registered.");
+        }
+
+        private static bool HasConnectionConfiguration(LassoOptions options)
+        {
+            return options.ConnectionMultiplexer != null
+                || options.RedisConfigurationOptions != null
+                || !string.IsNullOrWhiteSpace(options.RedisConfiguration);
         }
     }
 }

--- a/src/Lasso.Tests/Lasso.Tests.csproj
+++ b/src/Lasso.Tests/Lasso.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lasso.Tests/Lasso.Tests.csproj
+++ b/src/Lasso.Tests/Lasso.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
@@ -24,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lasso\Lasso.csproj" />
+    <ProjectReference Include="..\Lasso.Extensions.DependencyInjection\Lasso.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Lasso.Tests/LassoServiceDependencyInjectionTests.cs
+++ b/src/Lasso.Tests/LassoServiceDependencyInjectionTests.cs
@@ -1,0 +1,61 @@
+using Lasso.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Lasso.Tests
+{
+    public class LassoServiceDependencyInjectionTests
+    {
+        [Test]
+        public void AddDefaultLasso_ResolvesUsageManager()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultLasso();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.That(provider.GetRequiredService<IUsageManager>(), Is.TypeOf<RedisUsageManager>());
+        }
+
+        [Test]
+        public void AddLasso_WithoutConnectionConfiguration_FailsWhenHostStarts()
+        {
+            using IHost host = new HostBuilder()
+                .ConfigureServices((_, services) => services.AddLasso()
+                    .WithDailyUtcKeyBuilder()
+                    .WithTimeSpanExpirationStrategy(TimeSpan.FromMinutes(1), sliding: false))
+                .Build();
+
+            OptionsValidationException exception = Assert.ThrowsAsync<OptionsValidationException>(
+                async () => await host.StartAsync());
+            Assert.That(exception.Message, Does.Contain("A Redis connection must be configured"));
+        }
+
+        [Test]
+        public void AddLasso_WithBothExpirationStrategies_RejectsResolution()
+        {
+            var services = new ServiceCollection();
+            services.AddLasso(options => options.RedisConfiguration = "localhost:6379")
+                .WithDailyUtcKeyBuilder()
+                .WithTimeSpanExpirationStrategy(TimeSpan.FromMinutes(1), sliding: false)
+                .WithDateTimeExpirationStrategy(DateTime.UtcNow.AddMinutes(1));
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.That(
+                () => provider.GetRequiredService<IUsageManager>(),
+                Throws.InvalidOperationException.With.Message.EqualTo("Only one expiration strategy can be registered."));
+        }
+
+        [Test]
+        public void AddLasso_RejectsNullOptionsConfiguration()
+        {
+            var services = new ServiceCollection();
+
+            Assert.That(
+                () => services.AddLasso(configureOptionsFactory: null),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("configureOptionsFactory"));
+        }
+    }
+}

--- a/src/Lasso.Tests/RedisKeyBuilderTests.cs
+++ b/src/Lasso.Tests/RedisKeyBuilderTests.cs
@@ -1,4 +1,5 @@
 using StackExchange.Redis;
+using System.Globalization;
 
 namespace Lasso.Tests
 {
@@ -13,7 +14,7 @@ namespace Lasso.Tests
             int quota = 10;
             UsageRequest req = new UsageRequest(resource, context, quota);
             var key = builder.BuildRedisKey(req);
-            string expected = $"{DateTime.UtcNow.ToString("yyyyMMddHH")}:{context}";
+            string expected = $"{DateTime.UtcNow.ToString("yyyyMMddHH", CultureInfo.InvariantCulture)}:{context}";
             Assert.That(key, Is.EqualTo(expected));
         }
 
@@ -26,7 +27,7 @@ namespace Lasso.Tests
             int quota = 10;
             UsageRequest req = new UsageRequest(resource, context, quota);
             var key = builder.BuildRedisKey(req);
-            string expected = $"{DateTime.UtcNow.Date.ToString("yyyyMMdd")}:{context}";
+            string expected = $"{DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}:{context}";
             Assert.That(key, Is.EqualTo(expected));
         }
 
@@ -39,8 +40,40 @@ namespace Lasso.Tests
             int quota = 10;
             UsageRequest req = new UsageRequest(resource, context, quota);
             var key = builder.BuildRedisKey(req);
-            string expected = $"{DateTime.UtcNow.Date.ToString("yyyyMM01")}:{context}";
+            string expected = $"{DateTime.UtcNow.ToString("yyyyMM01", CultureInfo.InvariantCulture)}:{context}";
             Assert.That(key, Is.EqualTo(expected));
+        }
+
+        [TestCase("ar-SA")]
+        [TestCase("fa-IR")]
+        [TestCase("th-TH")]
+        public void Built_In_Builders_Use_Invariant_Calendar(string cultureName)
+        {
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+                UsageRequest request = new UsageRequest("resource", "context", 10);
+
+                AssertInvariantPeriod(new HourlyUtcRedisKeyBuilder(), request, "yyyyMMddHH");
+                AssertInvariantPeriod(new DailyUtcRedisKeyBuilder(), request, "yyyyMMdd");
+                AssertInvariantPeriod(new MonthlyUtcRedisKeyBuilder(), request, "yyyyMM01");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        private static void AssertInvariantPeriod(IRedisKeyBuilder builder, UsageRequest request, string format)
+        {
+            DateTime before = DateTime.UtcNow;
+            string key = builder.BuildRedisKey(request);
+            DateTime after = DateTime.UtcNow;
+
+            string expectedBefore = $"{before.ToString(format, CultureInfo.InvariantCulture)}:{request.Context}";
+            string expectedAfter = $"{after.ToString(format, CultureInfo.InvariantCulture)}:{request.Context}";
+            Assert.That(key, Is.EqualTo(expectedBefore).Or.EqualTo(expectedAfter));
         }
     }
 }

--- a/src/Lasso.Tests/RedisUsageManagerOwnershipTests.cs
+++ b/src/Lasso.Tests/RedisUsageManagerOwnershipTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+
+namespace Lasso.Tests
+{
+    public class RedisUsageManagerOwnershipTests
+    {
+        [Test]
+        public async Task Dispose_DoesNotDisposeSuppliedConnectionMultiplexer()
+        {
+            var database = new Mock<IDatabase>();
+            database
+                .Setup(x => x.KeyExpireTimeAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .ReturnsAsync((DateTime?)null);
+
+            var connection = new Mock<IConnectionMultiplexer>();
+            connection
+                .Setup(x => x.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+                .Returns(database.Object);
+
+            var options = Options.Create(new LassoOptions { ConnectionMultiplexer = connection.Object });
+            var manager = new RedisUsageManager(
+                options,
+                new DailyUtcRedisKeyBuilder(),
+                new TimeSpanExpirationStrategy(TimeSpan.FromMinutes(1), sliding: false));
+
+            await manager.GetExpirationAsync(new UsageRequest("resource", "context", 10));
+            manager.Dispose();
+
+            connection.Verify(x => x.Close(It.IsAny<bool>()), Times.Never);
+            connection.Verify(x => x.Dispose(), Times.Never);
+        }
+
+        [Test]
+        public void Constructor_RejectsMissingConnectionConfiguration()
+        {
+            var options = Options.Create(new LassoOptions());
+
+            OptionsValidationException exception = Assert.Throws<OptionsValidationException>(() =>
+                new RedisUsageManager(
+                    options,
+                    new DailyUtcRedisKeyBuilder(),
+                    new TimeSpanExpirationStrategy(TimeSpan.FromMinutes(1), sliding: false)));
+
+            Assert.That(exception.Message, Does.Contain("A Redis connection must be configured"));
+        }
+    }
+}

--- a/src/Lasso.Tests/RedisUsageManagerTests.cs
+++ b/src/Lasso.Tests/RedisUsageManagerTests.cs
@@ -11,7 +11,7 @@ namespace Lasso.Tests
         IRelativeExpirationStrategy expirationStrategy;
         IOptions<LassoOptions> options;
 
-        const string REDIS_URI = "127.0.0.1:6379";
+        static readonly string REDIS_URI = Environment.GetEnvironmentVariable("LASSO_TEST_REDIS_URI") ?? "127.0.0.1:6379";
 
         [SetUp]
         public void Setup()
@@ -21,6 +21,12 @@ namespace Lasso.Tests
             options = Options.Create<LassoOptions>(new LassoOptions { ConnectionMultiplexer = muxer });
             keyBuilder = new DailyUtcRedisKeyBuilder();
             expirationStrategy = new TimeSpanExpirationStrategy(TimeSpan.FromHours(1), false);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            muxer.Dispose();
         }
 
         [Test]

--- a/src/Lasso/DailyUtcRedisKeyBuilder.cs
+++ b/src/Lasso/DailyUtcRedisKeyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Lasso
 {
@@ -6,7 +7,7 @@ namespace Lasso
     {
         public string BuildRedisKey(UsageRequest usageRequest)
         {
-            return $"{DateTime.UtcNow.Date.ToString("yyyyMMdd")}:{usageRequest.Context}";
+            return $"{DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}:{usageRequest.Context}";
         }
     }
 }

--- a/src/Lasso/HourlyUtcRedisKeyBuilder.cs
+++ b/src/Lasso/HourlyUtcRedisKeyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Lasso
 {
@@ -6,7 +7,7 @@ namespace Lasso
     {
         public string BuildRedisKey(UsageRequest usageRequest)
         {
-            return $"{DateTime.UtcNow.ToString("yyyyMMddHH")}:{usageRequest.Context}";
+            return $"{DateTime.UtcNow.ToString("yyyyMMddHH", CultureInfo.InvariantCulture)}:{usageRequest.Context}";
         }
     }
 }

--- a/src/Lasso/Lasso.csproj
+++ b/src/Lasso/Lasso.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Joshua Marble</Authors>
     <PackageId>Lasso</PackageId>

--- a/src/Lasso/Lasso.csproj
+++ b/src/Lasso/Lasso.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Joshua Marble</Authors>
     <PackageId>Lasso</PackageId>
@@ -13,9 +13,9 @@ Lasso helps keep track of any kind of quotas or metrics by incrementing or decre
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lasso/Lasso.nuspec
+++ b/src/Lasso/Lasso.nuspec
@@ -14,15 +14,15 @@
     <readme>docs\README.md</readme>
     <license>docs\LICENSE</license>
     <dependencies>
-      <group targetFramework="netstandard2.0">
-        <dependency id="StackExchange.Redis" version="2.6.104" />
-        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="7.0.1" />
-        <dependency id="Microsoft.Extensions.Options" version="7.0.1" />
+      <group targetFramework="net10.0">
+        <dependency id="StackExchange.Redis" version="3.1.13" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" />
+        <dependency id="Microsoft.Extensions.Options" version="10.0.11" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Debug\netstandard2.0\Lasso.dll" target="lib\netstandard2.0\Lasso.dll" />
+    <file src="bin\Debug\net10.0\Lasso.dll" target="lib\net10.0\Lasso.dll" />
     <file src="..\..\README.md" target="docs\" />
     <file src="..\..\LICENSE" target="docs\" />
   </files>

--- a/src/Lasso/Lasso.nuspec
+++ b/src/Lasso/Lasso.nuspec
@@ -14,7 +14,7 @@
     <readme>docs\README.md</readme>
     <license>docs\LICENSE</license>
     <dependencies>
-      <group targetFramework="net10.0">
+      <group targetFramework="netstandard2.0">
         <dependency id="StackExchange.Redis" version="3.1.13" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" />
         <dependency id="Microsoft.Extensions.Options" version="10.0.11" />
@@ -22,7 +22,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Debug\net10.0\Lasso.dll" target="lib\net10.0\Lasso.dll" />
+    <file src="bin\Debug\netstandard2.0\Lasso.dll" target="lib\netstandard2.0\Lasso.dll" />
     <file src="..\..\README.md" target="docs\" />
     <file src="..\..\LICENSE" target="docs\" />
   </files>

--- a/src/Lasso/MonthlyUtcRedisKeyBuilder.cs
+++ b/src/Lasso/MonthlyUtcRedisKeyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Lasso
 {
@@ -6,7 +7,7 @@ namespace Lasso
     {
         public string BuildRedisKey(UsageRequest usageRequest)
         {
-            return $"{DateTime.UtcNow.Date.ToString("yyyyMM01")}:{usageRequest.Context}";
+            return $"{DateTime.UtcNow.ToString("yyyyMM01", CultureInfo.InvariantCulture)}:{usageRequest.Context}";
         }
     }
 }

--- a/src/Lasso/RedisUsageManager.cs
+++ b/src/Lasso/RedisUsageManager.cs
@@ -2,18 +2,16 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
-using System.Data.Common;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Threading;
-using System.Net.Sockets;
 
 namespace Lasso
 {
     public class RedisUsageManager : IUsageManager, IDisposable
     {
-        private volatile IConnectionMultiplexer connection;
+        private volatile IConnectionMultiplexer ownedConnection;
         private volatile IDatabase cache;
 
         private bool disposedValue;
@@ -25,6 +23,8 @@ namespace Lasso
         private readonly IFixedExpirationStrategy fixedExpirationStrategy;
         private readonly IRelativeExpirationStrategy relativeExpirationStrategy;
         private readonly ILogger logger;
+
+        private const string MissingConnectionConfigurationMessage = "A Redis connection must be configured with ConnectionMultiplexer, RedisConfigurationOptions, or RedisConfiguration.";
 
         public RedisUsageManager(IOptions<LassoOptions> options, IRedisKeyBuilder redisKeyBuilder, IRelativeExpirationStrategy expirationStrategy, ILogger logger = null)
             : this(options, redisKeyBuilder, logger)
@@ -46,6 +46,9 @@ namespace Lasso
             ArgumentNullThrowHelper.ThrowIfNull(redisKeyBuilder);
 
             this.options = options.Value;
+            if (!HasConnectionConfiguration(this.options))
+                throw new OptionsValidationException(Options.DefaultName, typeof(LassoOptions), new[] { MissingConnectionConfigurationMessage });
+
             this.keyBuilder = redisKeyBuilder;
             this.logger = logger ?? NullLoggerFactory.Instance.CreateLogger<RedisUsageManager>();
         }
@@ -151,8 +154,6 @@ namespace Lasso
                 else
                     await this.cache.KeyExpireAsync(key, fixedExpirationStrategy.Expiration).ConfigureAwait(false);
             }
-            else
-                Trace.TraceWarning("No key expiration strategy provided. Usage keys will persist for the life of the cluster.");
         }
 
         private void CheckDisposed()
@@ -183,14 +184,37 @@ namespace Lasso
                 if (cache is null)
                 {
                     IConnectionMultiplexer connection;
+                    bool ownsConnection;
                     if (options.ConnectionMultiplexer != null)
+                    {
                         connection = options.ConnectionMultiplexer;
+                        ownsConnection = false;
+                    }
                     else if (options.RedisConfigurationOptions != null)
+                    {
                         connection = await ConnectionMultiplexer.ConnectAsync(options.RedisConfigurationOptions);
+                        ownsConnection = true;
+                    }
                     else
+                    {
                         connection = await ConnectionMultiplexer.ConnectAsync(options.RedisConfiguration);
+                        ownsConnection = true;
+                    }
 
-                    cache = this.cache = connection.GetDatabase();
+                    try
+                    {
+                        cache = connection.GetDatabase();
+                    }
+                    catch
+                    {
+                        if (ownsConnection)
+                            ReleaseConnection(connection);
+                        throw;
+                    }
+
+                    if (ownsConnection)
+                        this.ownedConnection = connection;
+                    this.cache = cache;
                 }
                 Debug.Assert(this.cache != null);
                 return cache;
@@ -201,58 +225,16 @@ namespace Lasso
             }
         }
 
-        private void OnRedisError(Exception exception, IDatabase cache)
+
+        private static bool HasConnectionConfiguration(LassoOptions options)
         {
-            if ((exception is RedisConnectionException) || (exception is SocketException))
-            {
-                /*
-                var utcNow = DateTimeOffset.UtcNow;
-                var previousConnectTime = ReadTimeTicks(ref _lastConnectTicks);
-                TimeSpan elapsedSinceLastReconnect = utcNow - previousConnectTime;
-
-                // We want to limit how often we perform this top-level reconnect, so we check how long it's been since our last attempt.
-                if (elapsedSinceLastReconnect < ReconnectMinInterval)
-                {
-                    return;
-                }
-
-                var firstErrorTime = ReadTimeTicks(ref _firstErrorTimeTicks);
-                if (firstErrorTime == DateTimeOffset.MinValue)
-                {
-                    // note: order/timing here (between the two fields) is not critical
-                    WriteTimeTicks(ref _firstErrorTimeTicks, utcNow);
-                    WriteTimeTicks(ref _previousErrorTimeTicks, utcNow);
-                    return;
-                }
-
-                TimeSpan elapsedSinceFirstError = utcNow - firstErrorTime;
-                TimeSpan elapsedSinceMostRecentError = utcNow - ReadTimeTicks(ref _previousErrorTimeTicks);
-
-                bool shouldReconnect =
-                        elapsedSinceFirstError >= ReconnectErrorThreshold // Make sure we gave the multiplexer enough time to reconnect on its own if it could.
-                        && elapsedSinceMostRecentError <= ReconnectErrorThreshold; // Make sure we aren't working on stale data (e.g. if there was a gap in errors, don't reconnect yet).
-
-                // Update the previousErrorTime timestamp to be now (e.g. this reconnect request).
-                WriteTimeTicks(ref _previousErrorTimeTicks, utcNow);
-
-                if (!shouldReconnect)
-                {
-                    return;
-                }
-
-                WriteTimeTicks(ref _firstErrorTimeTicks, DateTimeOffset.MinValue);
-                WriteTimeTicks(ref _previousErrorTimeTicks, DateTimeOffset.MinValue);
-                */
-
-                // wipe the shared field, but *only* if it is still the cache we were
-                // thinking about (once it is null, the next caller will reconnect)
-                ReleaseConnection(Interlocked.CompareExchange(ref this.cache, null, cache));
-            }
+            return options.ConnectionMultiplexer != null
+                || options.RedisConfigurationOptions != null
+                || !string.IsNullOrWhiteSpace(options.RedisConfiguration);
         }
 
-        static void ReleaseConnection(IDatabase cache)
+        private void ReleaseConnection(IConnectionMultiplexer connection)
         {
-            var connection = cache?.Multiplexer;
             if (connection != null)
             {
                 try
@@ -262,7 +244,7 @@ namespace Lasso
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
+                    logger.LogWarning(ex, "An error occurred while disposing the Redis connection.");
                 }
             }
         }
@@ -273,7 +255,8 @@ namespace Lasso
             {
                 if (disposing)
                 {
-                    ReleaseConnection(Interlocked.Exchange(ref this.cache, null));
+                    Interlocked.Exchange(ref this.cache, null);
+                    ReleaseConnection(Interlocked.Exchange(ref this.ownedConnection, null));
                 }
 
                 disposedValue = true;


### PR DESCRIPTION
## Why

The repository review found several concrete reliability and usability defects: caller-owned Redis connections were disposed by Lasso, built-in keys varied by process culture, the default DI registration threw, invalid options failed late, and the public examples no longer compiled. The project and test infrastructure were also pinned to EOL .NET 6-era tooling and outdated dependencies.

This PR applies the first remediation batch while preserving broad NuGet consumer compatibility.

## What changed

### Redis reliability

- Preserve ownership of caller-supplied `IConnectionMultiplexer` instances.
- Dispose only multiplexers created by `RedisUsageManager`.
- Format daily, hourly, and monthly Redis keys with `InvariantCulture`.
- Log failures while disposing owned Redis connections.

### Dependency injection and configuration

- Fix parameterless `AddDefaultLasso()`, which previously registered defaults twice and always threw.
- Register `IUsageManager` through an explicit factory.
- Reject zero or multiple expiration strategies with actionable errors.
- Pass configured `ILogger<RedisUsageManager>` instances into the manager without breaking the existing public constructor signatures.
- Validate Redis connection options at host startup and during direct manager construction.

### Compatibility and modernization

| Component | Target |
|---|---|
| `Lasso` NuGet library | `netstandard2.0` |
| `Lasso.Extensions.DependencyInjection` NuGet library | `netstandard2.0` |
| Test project | `net10.0` |
| Demo | `net10.0` |
| CircleCI jobs | .NET 10 SDK |

The distributed libraries remain consumable from .NET 8 and other `netstandard2.0`-compatible applications. Tests, demo, and CI use .NET 10.

All package references were upgraded to the latest stable versions available from the configured feed, including Microsoft.Extensions 10.0.11, StackExchange.Redis 3.1.13, NUnit 4.6.1, and Microsoft.NET.Test.Sdk 18.8.1.

### Documentation and coverage

- Repair the README and demo against the current constructor and `UsageRequest` APIs.
- Handle nullable expiration values in examples.
- Compile the demo in CI.
- Add regression coverage for connection ownership, DI defaults, startup validation, strategy ambiguity, and non-Gregorian cultures.
- Make the integration-test Redis endpoint configurable through `LASSO_TEST_REDIS_URI`.
- Dispose the test fixture's shared Redis multiplexer.
- Add `CODE_REVIEW.md` with the validated findings, corrections, and remaining work.

## Compatibility notes

- Package TFMs remain `netstandard2.0`; a temporary `net8.0` consumer project successfully referenced the packed DI package.
- Redis connection misconfiguration now fails earlier and with a clear `OptionsValidationException`.
- Registering both fixed and relative expiration strategies now produces an explicit error instead of an ambiguous-constructor failure.
- StackExchange.Redis is upgraded from 2.6.122 to 3.1.13, so downstream release notes should call out the dependency major-version change.

## Verification

- Mixed-target solution build: passed with 0 warnings.
- Full .NET 10 test suite against `10.2.2.4:6379`: **33 passed, 0 failed, 0 skipped**.
- .NET 10 demo build: passed with 0 warnings.
- Release packs for both `netstandard2.0` libraries: succeeded.
- Temporary `net8.0` consumer referencing the packed DI NuGet package: built with 0 warnings.
- Outdated-package check: no updates available from the configured feed.
- Dependency vulnerability scan: no known vulnerabilities from the configured feed.

## Follow-up work

This is the first remediation batch. Atomic Redis mutation-plus-expiry and explicit batched-delivery guarantees remain separate design changes documented in `CODE_REVIEW.md`.
