### PR TITLE
ci(circleci): use .NET 10 Resolute image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-resolute
 
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
 
   test:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-resolute
 
     steps:
       - checkout
@@ -30,7 +30,8 @@ jobs:
       - run:
           name: Start Redis
           command: |
-            apk add redis
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends redis-server
             redis-server --daemonize yes
 
       - run:
@@ -47,7 +48,7 @@ jobs:
 
   semver:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-resolute
 
     steps:
       - checkout
@@ -68,13 +69,14 @@ jobs:
 
   deploy_nuget:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+      - image: mcr.microsoft.com/dotnet/sdk:10.0-resolute
 
     steps:
       - run:
           name: Install GitVersion and ssh
           command: |
-            apk add --no-cache bash openssh-client
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends bash openssh-client
             dotnet tool install --global gitversion.tool
 
       - add_ssh_keys:


### PR DESCRIPTION
## Summary

- switch every CircleCI job to `mcr.microsoft.com/dotnet/sdk:10.0-resolute`
- replace Alpine-specific `apk` package installation with Ubuntu `apt-get`
- make package installation noninteractive for CI

## Verification

- CircleCI MCP `validate_config`: valid
- exact Resolute image identified as Ubuntu 26.04 LTS with .NET SDK 10.0.400
- locally exercised the CI flow inside `mcr.microsoft.com/dotnet/sdk:10.0-resolute`
- Redis installed and started successfully (`PONG`)
- solution build passed with 0 warnings and 0 errors
- demo build passed with 0 warnings and 0 errors
- test suite passed: 33 passed, 0 failed, 0 skipped
- GitVersion 6.8.2 installed and executed successfully
- OpenSSH client installation succeeded
