### PR TITLE
fix(ci): migrate GitVersion config to v6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,7 @@ jobs:
       - run:
           name: Install GitVersion
           command: |
-            apk add --no-cache bash
-            dotnet tool install --global gitversion.tool
+            dotnet tool install --global gitversion.tool --version 6.8.2
 
       - run:
           name: Get Version
@@ -79,7 +78,7 @@ jobs:
           command: |
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends bash openssh-client
-            dotnet tool install --global gitversion.tool
+            dotnet tool install --global gitversion.tool --version 6.8.2
 
       - add_ssh_keys:
             fingerprints:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,14 +1,19 @@
-mode: Mainline
+workflow: GitHubFlow/v1
+label: null
+strategies:
+  - Mainline
 branches:
   main:
     regex: ^master$|^main$
-    tag: ''
+    label: null
+    mode: ContinuousDeployment
     increment: Patch
-  branch:
-    regex: ^[^\s\\]$
-    source-branches: ['master', 'main', 'feature']
-    tag: Alpha
+    is-main-branch: true
+  unknown:
+    regex: (?<BranchName>.+)
+    label: '{BranchName}'
     increment: Patch
+    source-branches:
+      - main
 ignore:
   sha: []
-merge-message-formats: {}


### PR DESCRIPTION
## Problem

After #22 moved CircleCI to Ubuntu Resolute:

- `semver` still invoked Alpine's `apk`, so main build 215 exited with code 127 before installing GitVersion
- GitVersion 6.8.2 rejects the repository's GitVersion 5 configuration (`mode: Mainline` and `tag`)
- the unpinned global tool could change release behavior without a repository change

## Fix

- remove the stale `apk` call from the Resolute semver job
- pin `gitversion.tool` 6.8.2 in both semver and deploy jobs
- migrate `GitVersion.yml` to the v6 GitHub Flow schema
- use the v6 `Mainline` strategy with stable `ContinuousDeployment` versions on `main`
- retain branch-name prerelease labels and patch increments

This replaces #23, whose diff was based before #22 and would revert all jobs to Alpine.

## Version compatibility

Validated against the existing repository history and tags:

| Scenario | GitVersion 5 | Migrated GitVersion 6 |
|---|---:|---:|
| Current `main` | `0.11.2` | `0.11.2` |
| One new `ci/probe` commit | `0.11.3-ci-probe.1` | `0.11.3-ci-probe.1` |

The migrated release commands also updated both project files and packed both NuGet packages successfully as version `0.11.2`.

## Verification

- CircleCI MCP `validate_config`: valid
- GitVersion 6.8.2 main output: `0.11.2`
- GitVersion 6.8.2 branch output: `0.11.3-fix-circleci-gitversion6.1`
- migrated `/updateprojectfiles` commands: passed
- release pack: both NuGet packages created successfully
- whitespace validation: passed
- PR CircleCI pipeline: all jobs passed
  - `semver` #220
  - `build` #221
  - `test` #222
  - `deploy_nuget` #223

## External release prerequisite

Main build 214 published NuGet successfully and then failed while pushing release metadata because CircleCI's SSH deploy key is read-only. Per the selected release policy, the existing key (or its replacement) must be granted repository write access in GitHub/CircleCI before the main deploy job can push tags successfully.
